### PR TITLE
docker-push: Remove pushing latest tag

### DIFF
--- a/bin/docker-push
+++ b/bin/docker-push
@@ -4,19 +4,6 @@
 
 echo "Pushing $DOCKERTAG:latest as $CI_SHA1, $CI_BRANCH, $CI_BUILD_NUM to ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}"
 
-docker tag $DOCKERTAG:latest ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:latest
-if [ $? -ne 0 ]
-then
-  echo "Unable to tag image, aborting"
-  exit 1
-fi
-docker push ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:latest
-if [ $? -ne 0 ]
-then
-  echo "Unable to push docker image, aborting."
-  exit 1
-fi
-
 docker tag $DOCKERTAG:latest ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$CI_SHA1
 if [ $? -ne 0 ]
 then


### PR DESCRIPTION
`latest` should be generated by the repo. Pushing `latest` into ECR 
requires a -f but also isn’t used by us (I think).

k8s-scripts push SHA tags as well which are used in the deploy process
for images uses `latest`.

@sairez 