### PR TITLE
Updates to docker caching, and handling of `latest`

### DIFF
--- a/bin/docker-build
+++ b/bin/docker-build
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. k8s-read-config "$@"
+# . k8s-read-config "$@"
 
 echo "Building $DOCKERTAG from $BASEDIR/$DOCKERFILE"
 docker build --rm=false -t $DOCKERTAG -f ${BASEDIR}/$DOCKERFILE ${BASEDIR}

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# . k8s-read-config "$@"
+. k8s-read-config "$@"
 
 echo "Building $DOCKERTAG from $BASEDIR/$DOCKERFILE"
 docker build --rm=false -t $DOCKERTAG -f ${BASEDIR}/$DOCKERFILE ${BASEDIR}

--- a/bin/docker-pull
+++ b/bin/docker-pull
@@ -10,5 +10,9 @@ else
 	eval $(aws ecr get-login --region $AWS_DEFAULT_REGION --registry-ids ${AWS_ECR_ACCOUNT_ID})
 fi
 
-# this should exit 0 even if the image is not there. For example, on a first run
-docker pull ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:latest || true
+# Warm the local docker cache (aka the local docker iamges) by pulling the previous commit and the images
+# tagged with the current branch, if they exist.
+# This should exit 0 even if the image is not there. For example, on a first run
+PREVIOUS_COMMIT=$(git rev-parse HEAD~1)
+docker pull ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$PREVIOUS_COMMIT || true
+docker pull ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$CI_BRANCH || true

--- a/bin/docker-pull
+++ b/bin/docker-pull
@@ -10,7 +10,7 @@ else
 	eval $(aws ecr get-login --region $AWS_DEFAULT_REGION --registry-ids ${AWS_ECR_ACCOUNT_ID})
 fi
 
-# Warm the local docker cache (aka the local docker iamges) by pulling the previous commit and the images
+# Warm the local docker cache (aka the local docker images) by pulling the previous commit and the images
 # tagged with the current branch, if they exist.
 # This should exit 0 even if the image is not there. For example, on a first run
 PREVIOUS_COMMIT=$(git rev-parse HEAD~1)

--- a/bin/docker-push
+++ b/bin/docker-push
@@ -17,7 +17,7 @@ then
   exit 1
 fi
 
-docker tag $DOCKERTAG:latest ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$CI_BRANCH
+docker tag -f $DOCKERTAG:latest ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$CI_BRANCH
 if [ $? -ne 0 ]
 then
   echo "Unable to tag image, aborting"


### PR DESCRIPTION
#4 ended pushing the docker image tagged `latest`. Here, we improve the docker caching strategy by pulling docker images that are most likely to be needed for the subsequent `docker build,` namely an image tagged with the previous commit, and the image tagged with the current branch.

`docker tag -f` is added here for pushing images tagged with the branch so that they will succeed in being pushed and overwrite any other image that is tagged with that branch. Since we never deploy a docker image by referring to an image's branch name, this won't overwrite in a destructive way.

It's useful for the cases in which there are images associated with the branch, but not any matching the previous commit. (For example, a developer has committed a few times before pushing). As this image will be on the same branch as the current `docker build` that is about to be run, it's likely that most of the docker image layers will be reusable. 
