### PR TITLE
Exit if required variables are empty

### DIFF
--- a/bin/docker-build
+++ b/bin/docker-build
@@ -2,6 +2,10 @@
 
 . k8s-read-config "$@"
 
+if [ -z "$BASEDIR" ];    then echo BASEDIR must be set; exit 1; fi
+if [ -z "$DOCKERTAG" ];  then echo DOCKERTAG must be set; exit 1; fi
+if [ -z "$DOCKERFILE" ]; then echo DOCKERFILE must be set; exit 1; fi
+
 echo "Building $DOCKERTAG from $BASEDIR/$DOCKERFILE"
 docker build --rm=false -t $DOCKERTAG -f ${BASEDIR}/$DOCKERFILE ${BASEDIR}
 if [ $? -ne 0 ]

--- a/bin/docker-pull
+++ b/bin/docker-pull
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+if [ -z "$EXTERNAL_REGISTRY_BASE_DOMAIN" ]; then echo EXTERNAL_REGISTRY_BASE_DOMAIN must be set; exit 1; fi
+if [ -z "$REPOSITORY_NAME" ];               then echo REPOSITORY_NAME must be set; exit 1; fi
+
 if ! hash aws 2>/dev/null; then
   pip install awscli
 fi

--- a/bin/docker-push
+++ b/bin/docker-push
@@ -2,6 +2,13 @@
 
 . k8s-read-config "$@"
 
+if [ -z "$EXTERNAL_REGISTRY_BASE_DOMAIN" ]; then echo EXTERNAL_REGISTRY_BASE_DOMAIN must be set; exit 1; fi
+if [ -z "$REPOSITORY_NAME" ];               then echo REPOSITORY_NAME must be set; exit 1; fi
+if [ -z "$DOCKERTAG" ];                     then echo DOCKERTAG must be set; exit 1; fi
+if [ -z "$CI_SHA1" ];                       then echo CI_SHA1 must be set; exit 1; fi
+if [ -z "$CI_BRANCH" ];                     then echo CI_BRANCH must be set; exit 1; fi
+if [ -z "$CI_BUILD_NUM" ];                  then echo CI_BUILD_NUM must be set; exit 1; fi
+
 echo "Pushing $DOCKERTAG:latest as $CI_SHA1, $CI_BRANCH, $CI_BUILD_NUM to ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}"
 
 docker tag $DOCKERTAG:latest ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$CI_SHA1


### PR DESCRIPTION
Backport from upstream where this was already merged.

Not designed to hit all of the possibly needed ENVVARs but catch ones
that may come up first.