### PR TITLE
docker-pull: Remove /’s from branch name

### DIFF
--- a/bin/docker-pull
+++ b/bin/docker-pull
@@ -17,5 +17,6 @@ fi
 # tagged with the current branch, if they exist.
 # This should exit 0 even if the image is not there. For example, on a first run
 PREVIOUS_COMMIT=$(git rev-parse HEAD~1)
+CI_BRANCH=$(echo $CI_BRANCH | tr / _)
 docker pull ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$PREVIOUS_COMMIT || true
 docker pull ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$CI_BRANCH || true


### PR DESCRIPTION
/’s are not valid in docker tags. These are removed in the docker-push
but they were not removed here. 

There is still a chance of a collision however this is an optimization
and does not rely on these branch names for correctness (I think).