### PR TITLE
docker-run: Add script to run after reading config

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Does a build of the current directory
 
 Pulls from the registry the most recent build of the image. Useful for CI/CD layer caching
 
+### docker-run
+
+Runs `docker run` for the `$DOCKERTAG` after reading your config. If `-f` is used it must be defined first.
+
 ### docker-push
 
 Pushes the recently build image to the registry

--- a/bin/docker-run
+++ b/bin/docker-run
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+. k8s-read-config "$@"
+
+# Skip config file if specified, required to be first.
+if [[ "${1}" = "-f" ]]; then
+  shift 2
+fi
+
+docker run "${DOCKERTAG}" "${*}"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "prepare-kubectl": "./bin/prepare-kubectl",
     "docker-build": "./bin/docker-build",
     "docker-push": "./bin/docker-push",
-    "docker-pull": "./bin/docker-pull"
+    "docker-pull": "./bin/docker-pull",
+    "docker-run": "./bin/docker-run"
   },
   "author": "Ross Kukulinski <ross@kukulinski.com>",
   "license": "MIT",


### PR DESCRIPTION
So we can keep a standard `run` call across invocations. Needed as at
least one use includes the `DOCKERTAG` as part of the config. This way any
changes in the config will be reflected easily in the `run`.