### PR TITLE
Revert "Add k8s-read-config to docker-pull"

### DIFF
--- a/bin/docker-pull
+++ b/bin/docker-pull
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-. k8s-read-config "$@"
-
 if [ -z "$EXTERNAL_REGISTRY_BASE_DOMAIN" ]; then echo EXTERNAL_REGISTRY_BASE_DOMAIN must be set; exit 1; fi
 if [ -z "$REPOSITORY_NAME" ];               then echo REPOSITORY_NAME must be set; exit 1; fi
 


### PR DESCRIPTION
This reverts commit b8cf2604fc1f46e7620332be0ab1a54660cf9033.

This commit is backwards incompatible with existing usage of
`docker-pull` which doesn't use `-f` to specify the config. Usage may
fail to find the default config file, if a default exist it could cause
problems for usage.

Closes #47 

This can be re-added in a v4 release